### PR TITLE
Return the inputed value if selection not present in the index.

### DIFF
--- a/grizzl-read.el
+++ b/grizzl-read.el
@@ -94,8 +94,8 @@ Each key pressed in the minibuffer filters down the list of matches."
                         (remove-hook 'post-command-hook    hookfun t))))
           (add-hook 'minibuffer-exit-hook exitfun nil t)
           (add-hook 'post-command-hook    hookfun nil t)))
-    (read-from-minibuffer ">>> ")
-    (grizzl-selected-result index)))
+    (let ((read-value (read-from-minibuffer ">>> ")))
+      (or (grizzl-selected-result index) read-value))))
 
 ;;;###autoload
 (defun grizzl-selected-result (index)


### PR DESCRIPTION
When the inputed string is not found in the index the nil is returned. I think it's better to just return the string. Also `ido-completing-read` and `completing-read` commands have the `require-match` argument. I could implement it for `grizzl-completing-read`.