### PR TITLE
add cl as dependency for grizzl-read

### DIFF
--- a/grizzl-core.el
+++ b/grizzl-core.el
@@ -42,7 +42,8 @@
 ;;
 
 (eval-when-compile
-  (require 'cl))
+  (require 'cl)
+  (require 'cl-lib))
 
 ;;; --- Public Functions
 

--- a/grizzl-core.el
+++ b/grizzl-core.el
@@ -42,7 +42,7 @@
 ;;
 
 (eval-when-compile
-  (require 'cl-lib))
+  (require 'cl))
 
 ;;; --- Public Functions
 

--- a/grizzl-read.el
+++ b/grizzl-read.el
@@ -40,7 +40,8 @@
 ;;
 
 (eval-when-compile
-  (require 'cl))
+  (require 'cl)
+  (require 'cl-lib))
 
 ;;; --- Configuration Variables
 

--- a/grizzl-read.el
+++ b/grizzl-read.el
@@ -40,7 +40,7 @@
 ;;
 
 (eval-when-compile
-  (require 'cl-lib))
+  (require 'cl))
 
 ;;; --- Configuration Variables
 


### PR DESCRIPTION
Basically, when grizzl is compiled without `cl`, displaying the completion list results in the following error:

```
Symbol's function definition is void: exitfun
```

This scenario happens when installing `grizzl` with `(package-install 'grizzl)` inside init.el.

More details in d11wtq/fiplr#15.